### PR TITLE
Add ZFS cache awareness to memory meters.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,11 @@ else
             [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
 fi
 
+AC_ARG_ENABLE(zfs_cache_awareness, [AC_HELP_STRING([--enable-zfs-cache-awareness],[enable ZFS cache awareness for memory usage])], enable_zfs_cache_awareness="yes",enable_zfs_cache_awareness="no")
+if test "x$enable_zfs_cache_awareness" = xyes; then
+    AC_DEFINE(HAVE_ZFS, 1, [Define if we want the memory meter to be aware of the ZFS cache])
+fi
+
 if test "$my_htop_platform" = "freebsd"; then
    AC_CHECK_LIB([kvm], [kvm_open], [], [missing_libraries="$missing_libraries libkvm"])
 fi

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -108,6 +108,10 @@ typedef struct LinuxProcessList_ {
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
 #endif
 
+#ifndef ZFSINFOFILE
+#define ZFSINFOFILE "/proc/spl/kstat/zfs/arcstats"
+#endif
+
 #ifndef PROCTTYDRIVERSFILE
 #define PROCTTYDRIVERSFILE PROCDIR "/tty/drivers"
 #endif
@@ -115,7 +119,6 @@ typedef struct LinuxProcessList_ {
 #ifndef PROC_LINE_LENGTH
 #define PROC_LINE_LENGTH 4096
 #endif
-
 }*/
 
 #ifndef CLAMP
@@ -957,6 +960,31 @@ static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
       }
       #undef tryRead
    }
+
+#ifdef HAVE_ZFS
+   FILE* zfsFile = fopen(ZFSINFOFILE,"r");
+   if( zfsFile != NULL)
+   {
+      unsigned long long int zfsMem = 0;
+      while(fgets(buffer,128,zfsFile) && zfsMem == 0)
+      {
+         switch(buffer[0])
+         {
+            case 's':
+               if(String_startsWith(buffer, "size"))
+                  sscanf(buffer,"size %*i %32llu",&zfsMem);
+                  zfsMem /= 1024;
+                  break;
+            default:
+               break;
+         }
+      }
+      this->cachedMem += zfsMem;
+      fclose(zfsFile);
+   }
+#endif
+
+
 
    this->usedMem = this->totalMem - this->freeMem;
    this->cachedMem = this->cachedMem + sreclaimable - shmem;

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -81,6 +81,10 @@ typedef struct LinuxProcessList_ {
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
 #endif
 
+#ifndef ZFSINFOFILE
+#define ZFSINFOFILE "/proc/spl/kstat/zfs/arcstats"
+#endif
+
 #ifndef PROCTTYDRIVERSFILE
 #define PROCTTYDRIVERSFILE PROCDIR "/tty/drivers"
 #endif


### PR DESCRIPTION
Enable with --enable-zfs-cache-awareness

(Only tested with ZFS on linux)